### PR TITLE
add contains list

### DIFF
--- a/binspec-visualizer/app/components/data-segment-details.hbs
+++ b/binspec-visualizer/app/components/data-segment-details.hbs
@@ -8,7 +8,7 @@
 
   {{#if (gt @segment.children.length 0)}}
     <DataSegmentDetails::Children
-      class="mt-2"
+      {{!-- class="mt-1" --}}
       @segment={{@segment}}
       @onSegmentSelect={{@onSegmentSelect}}
       @onSegmentMouseEnter={{@onSegmentMouseEnter}}

--- a/binspec-visualizer/app/components/data-segment-details.hbs
+++ b/binspec-visualizer/app/components/data-segment-details.hbs
@@ -8,7 +8,7 @@
 
   {{#if (gt @segment.children.length 0)}}
     <DataSegmentDetails::Children
-      {{!-- class="mt-1" --}}
+      class="mt-1"
       @segment={{@segment}}
       @onSegmentSelect={{@onSegmentSelect}}
       @onSegmentMouseEnter={{@onSegmentMouseEnter}}
@@ -22,24 +22,26 @@
     </div>
   {{/if}}
 
-  <HexPreview
-    class="mt-3 w-full"
-    @data={{@data}}
-    @endByteIndex={{this.previewEndByteIndex}}
-    @highlightedSegment={{@segment}}
-    @onSegmentMouseEnter={{@onSegmentMouseEnter}}
-    @onSegmentMouseLeave={{@onSegmentMouseLeave}}
-    @onSegmentSelect={{@onSegmentSelect}}
-    @section="segment-details-hexdump"
-    @segments={{array @segment}}
-    @startByteIndex={{@segment.startByteIndex}}
-  >
-    <:lastBytePreview>
-      {{#if this.previewIsTruncated}}
-        <div class="flex items-center justify-center">
-          <span class="text-lg text-zinc-500">⋯</span>
-        </div>
-      {{/if}}
-    </:lastBytePreview>
-  </HexPreview>
+  {{#if @segment.isLeafSegment}}
+    <HexPreview
+      class="mt-3 w-full"
+      @data={{@data}}
+      @endByteIndex={{this.previewEndByteIndex}}
+      @highlightedSegment={{@segment}}
+      @onSegmentMouseEnter={{@onSegmentMouseEnter}}
+      @onSegmentMouseLeave={{@onSegmentMouseLeave}}
+      @onSegmentSelect={{@onSegmentSelect}}
+      @section="segment-details-hexdump"
+      @segments={{array @segment}}
+      @startByteIndex={{@segment.startByteIndex}}
+    >
+      <:lastBytePreview>
+        {{#if this.previewIsTruncated}}
+          <div class="flex items-center justify-center">
+            <span class="text-lg text-zinc-500">⋯</span>
+          </div>
+        {{/if}}
+      </:lastBytePreview>
+    </HexPreview>
+  {{/if}}
 </div>

--- a/binspec-visualizer/app/components/data-segment-details/children.hbs
+++ b/binspec-visualizer/app/components/data-segment-details/children.hbs
@@ -1,22 +1,16 @@
-<div class="flex items-center flex-wrap gap-1" ...attributes>
-  <span class="text-xs text-zinc-400/80 uppercase font-medium">
+<div ...attributes>
+  {{!-- <span class="text-xs text-zinc-400/80 uppercase font-medium mb-1">
     Contains:
-  </span>
+  </span> --}}
 
   {{#each @segment.children as |child|}}
-    <span
-      class="inline-flex flex-shrink-0 items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset
-        {{if
-          (segment-eq child this.hoveredSegment)
-          'ring-blue-400/20 bg-blue-400/10 text-blue-400'
-          'ring-gray-400/20 bg-gray-400/10 text-gray-400'
-        }}"
-      role="button"
-      {{on "click" (fn @onSegmentSelect child)}}
+    <SegmentAncestorsTooltipItem
+      @segment={{child}}
+      @highlightedSegment={{@segment}}
+      @indentationLevel={{0}}
       {{on "mouseenter" (fn @onSegmentMouseEnter "other" child undefined)}}
       {{on "mouseleave" @onSegmentMouseLeave}}
-    >
-      {{child.titleForDisplay}}
-    </span>
+      {{on "click" (fn @onSegmentSelect child)}}
+    />
   {{/each}}
 </div>

--- a/binspec-visualizer/app/components/data-segment-details/children.hbs
+++ b/binspec-visualizer/app/components/data-segment-details/children.hbs
@@ -1,13 +1,13 @@
 <div ...attributes>
   {{!-- <span class="text-xs text-zinc-400/80 uppercase font-medium mb-1">
-    Contains:
+    Children:
   </span> --}}
 
   {{#each @segment.children as |child|}}
     <SegmentAncestorsTooltipItem
       @segment={{child}}
       @highlightedSegment={{@segment}}
-      @indentationLevel={{0}}
+      @indentationLevel={{1}}
       {{on "mouseenter" (fn @onSegmentMouseEnter "other" child undefined)}}
       {{on "mouseleave" @onSegmentMouseLeave}}
       {{on "click" (fn @onSegmentSelect child)}}

--- a/binspec-visualizer/app/components/data-segment-details/title-with-breadcrumbs.hbs
+++ b/binspec-visualizer/app/components/data-segment-details/title-with-breadcrumbs.hbs
@@ -8,16 +8,13 @@
     >
       …
 
-      {{#if this.ancestorTreeTooltipIsOpen}}
-        <SegmentAncestorsTooltip
-          @segment={{@segment}}
-          @highlightedSegment={{@segment}}
-          @onSegmentMouseEnter={{@onSegmentMouseEnter}}
-          @onSegmentMouseLeave={{@onSegmentMouseLeave}}
-          @onSegmentSelect={{@onSegmentSelect}}
-          {{click-outside this.handleAncestorTreeTooltipClose}}
-        />
-      {{/if}}
+      <SegmentAncestorsTooltip
+        @segment={{@segment}}
+        @highlightedSegment={{@segment}}
+        @onSegmentMouseEnter={{@onSegmentMouseEnter}}
+        @onSegmentMouseLeave={{@onSegmentMouseLeave}}
+        @onSegmentSelect={{@onSegmentSelect}}
+      />
     </div>
 
     <svg

--- a/binspec-visualizer/app/components/data-segment-details/title-with-breadcrumbs.hbs
+++ b/binspec-visualizer/app/components/data-segment-details/title-with-breadcrumbs.hbs
@@ -33,7 +33,6 @@
   {{#if @segment.parent}}
     {{! template-lint-disable require-presentational-children }}
     <div
-      dir="rtl"
       role="button"
       class="border-b-2 font-medium text-base sm:text-lg truncate flex-shrink max-w-[14em]
         {{if

--- a/binspec-visualizer/app/components/hex-preview.ts
+++ b/binspec-visualizer/app/components/hex-preview.ts
@@ -167,6 +167,7 @@ export default class HexPreview extends Component<Signature> {
       );
     }
 
+    // If we're within a highlighted segment, we only allow hover if child segments exist.
     if (highlightedSegment.containsByteIndex(byteIndex)) {
       return highlightedSegment.children.find((child) =>
         child.containsByteIndex(byteIndex),

--- a/binspec-visualizer/app/components/segment-ancestors-tooltip-item.hbs
+++ b/binspec-visualizer/app/components/segment-ancestors-tooltip-item.hbs
@@ -24,6 +24,8 @@
       />
     </svg>
 
-    <span class="text-sm border-b-2 {{this.textColorClasses}}">{{@segment.titleForDisplay}}</span>
+    <span
+      class="text-sm border-b-2 {{this.textColorClasses}}"
+    >{{@segment.titleForDisplay}}</span>
   </div>
 </div>

--- a/binspec-visualizer/app/components/segment-ancestors-tooltip-item.hbs
+++ b/binspec-visualizer/app/components/segment-ancestors-tooltip-item.hbs
@@ -24,6 +24,6 @@
       />
     </svg>
 
-    <span class={{this.textColorClasses}}>{{@segment.titleForDisplay}}</span>
+    <span class="text-sm border-b-2 {{this.textColorClasses}}">{{@segment.titleForDisplay}}</span>
   </div>
 </div>

--- a/binspec-visualizer/app/components/segment-ancestors-tooltip-item.ts
+++ b/binspec-visualizer/app/components/segment-ancestors-tooltip-item.ts
@@ -38,11 +38,11 @@ export default class SegmentAncestorsTooltipItemComponent extends Component<Sign
 
   get textColorClasses(): string {
     if (this.isHighlightedSegment) {
-      return 'text-yellow-300';
+      return 'border-transparent text-yellow-300';
     } else if (this.isHoveredSegment) {
-      return 'text-sky-400';
+      return 'border-sky-400/60 text-sky-400';
     } else {
-      return 'text-white';
+      return 'border-zinc-400/20 text-white';
     }
   }
 

--- a/binspec-visualizer/app/components/segment-ancestors-tooltip.hbs
+++ b/binspec-visualizer/app/components/segment-ancestors-tooltip.hbs
@@ -1,9 +1,8 @@
 <EmberPopover
-  @isShown={{true}}
   @side="bottom-start"
-  @event="none"
   @tooltipClass="bg-zinc-800 border-zinc-600/80 text-white py-2 px-1 max-w-[360px]"
   @effect="none"
+  @popoverHideDelay={{100}}
   ...attributes
 >
   {{#each this.ancestorsAndSelf as |segment segmentIndex|}}

--- a/binspec-visualizer/app/controllers/format.ts
+++ b/binspec-visualizer/app/controllers/format.ts
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import type HoverStateService from 'binspec-visualizer/services/hover-state';
 import type { ModelType } from 'binspec-visualizer/routes/format';
+import { next } from '@ember/runloop';
 
 export default class FormatController extends Controller {
   declare model: ModelType;
@@ -23,7 +24,6 @@ export default class FormatController extends Controller {
 
   @action
   handleClickOutside() {
-    console.log('click outside triggered');
     this.hoverState.clear();
     this.highlightedSegment = undefined;
   }
@@ -55,5 +55,9 @@ export default class FormatController extends Controller {
   handleSegmentSelected(segment: DataSegment) {
     this.highlightedSegment = segment;
     this.hoverState.clear();
+
+    next(() => {
+      this.hoverState.clear(); // If interstitial jumps and we trigger hover, let's clear that too
+    });
   }
 }

--- a/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0-unknown-topic.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0-unknown-topic.ts
@@ -92,7 +92,7 @@ const generated: GeneratedData = {
               "explanation_markdown": "The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.\n"
             },
             {
-              "title": "Topics",
+              "title": "Topic #1",
               "explanation_markdown": "A single topic in the array.\n",
               "children": [
                 {

--- a/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0.ts
@@ -148,7 +148,7 @@ const generated: GeneratedData = {
               "explanation_markdown": "The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.\n"
             },
             {
-              "title": "Topics",
+              "title": "Topic #1",
               "explanation_markdown": "A single topic in the array.\n",
               "children": [
                 {

--- a/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0-unknown-topic.yml
+++ b/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0-unknown-topic.yml
@@ -109,7 +109,7 @@ segments:
             length_in_bytes: 1
             explanation_markdown: |
               The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.
-          - title: Topics
+          - title: "Topic #1"
             explanation_markdown: |
               A single topic in the array.
             children:

--- a/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0.yml
+++ b/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0.yml
@@ -165,7 +165,7 @@ segments:
             length_in_bytes: 1
             explanation_markdown: |
               The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.
-          - title: Topics
+          - title: "Topic #1"
             explanation_markdown: |
               A single topic in the array.
             children:


### PR DESCRIPTION
- Refactor SegmentAncestorsTooltip usage and update tooltip properties.
- Refactor DataSegmentDetails and SegmentAncestorsTooltipItem components styles.
- Format span element for better readability in segment ancestors tooltip.
- Refactor HexPreview rendering based on segment type and adjust indentation level.
- Remove console log and add next() to clear hover state after segment selection.
