### PR TITLE
Fix topic partition response data structures

### DIFF
--- a/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0.ts
@@ -249,49 +249,34 @@ const generated: GeneratedData = {
                         },
                         {
                           "title": "Eligible Leader Replicas",
-                          "explanation_markdown": "An array of eligible leader replica node IDs for this partition.\n",
+                          "explanation_markdown": "An array of eligible leader replica node IDs (int32) for this partition.\n",
                           "children": [
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
                               "explanation_markdown": "The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
-                            },
-                            {
-                              "title": "Eligible Leader Replica Node",
-                              "length_in_bytes": 0,
-                              "explanation_markdown": "A 4-byte integer representing an eligible leader replica node ID.\nHere, this field is empty.\n"
                             }
                           ]
                         },
                         {
                           "title": "Last Known ELR",
-                          "explanation_markdown": "An array of last known eligible leader replica node IDs for this partition.\n",
+                          "explanation_markdown": "An array of last known eligible leader replica node IDs (int32) for this partition.\n",
                           "children": [
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
                               "explanation_markdown": "The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
-                            },
-                            {
-                              "title": "Last Known ELR Node",
-                              "length_in_bytes": 0,
-                              "explanation_markdown": "A 4-byte integer representing a last known eligible leader replica node ID.\nHere, this field is empty.\n"
                             }
                           ]
                         },
                         {
                           "title": "Offline Replicas",
-                          "explanation_markdown": "An array of offline replica node IDs for this partition.\n",
+                          "explanation_markdown": "An array of offline replica node IDs (int32) for this partition.\n",
                           "children": [
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
                               "explanation_markdown": "The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
-                            },
-                            {
-                              "title": "Offline Replica Node",
-                              "length_in_bytes": 0,
-                              "explanation_markdown": "A 4-byte integer representing a last known eligible leader replica node ID.\nHere, this field is empty.\n"
                             }
                           ]
                         },
@@ -360,49 +345,34 @@ const generated: GeneratedData = {
                         },
                         {
                           "title": "Eligible Leader Replicas",
-                          "explanation_markdown": "An array of eligible leader replica node IDs for this partition.\n",
+                          "explanation_markdown": "An array of eligible leader replica node IDs (int32) for this partition.\n",
                           "children": [
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
                               "explanation_markdown": "The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
-                            },
-                            {
-                              "title": "Eligible Leader Replica Node",
-                              "length_in_bytes": 0,
-                              "explanation_markdown": "A 4-byte integer representing an eligible leader replica node ID.\nHere, this field is empty.\n"
                             }
                           ]
                         },
                         {
                           "title": "Last Known ELR",
-                          "explanation_markdown": "An array of last known eligible leader replica node IDs for this partition.\n",
+                          "explanation_markdown": "An array of last known eligible leader replica node IDs (int32) for this partition.\n",
                           "children": [
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
                               "explanation_markdown": "The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
-                            },
-                            {
-                              "title": "Last Known ELR Node",
-                              "length_in_bytes": 0,
-                              "explanation_markdown": "A 4-byte integer representing a last known eligible leader replica node ID.\nHere, this field is empty.\n"
                             }
                           ]
                         },
                         {
                           "title": "Offline Replicas",
-                          "explanation_markdown": "An array of offline replica node IDs for this partition.\n",
+                          "explanation_markdown": "An array of offline replica node IDs (int32) for this partition.\n",
                           "children": [
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
                               "explanation_markdown": "The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
-                            },
-                            {
-                              "title": "Offline Replica Node",
-                              "length_in_bytes": 0,
-                              "explanation_markdown": "A 4-byte integer representing a last known eligible leader replica node ID.\nHere, this field is empty.\n"
                             }
                           ]
                         },

--- a/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0.ts
@@ -249,18 +249,51 @@ const generated: GeneratedData = {
                         },
                         {
                           "title": "Eligible Leader Replicas",
-                          "length_in_bytes": 1,
-                          "explanation_markdown": "The count of eligible leader replicas + 1, encoded as a varint.\nHere, it is 0x01 (1), indicating 0 eligible leader replicas.\n"
+                          "explanation_markdown": "An array of eligible leader replica node IDs for this partition.\n",
+                          "children": [
+                            {
+                              "title": "Array Length",
+                              "length_in_bytes": 1,
+                              "explanation_markdown": "The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                            },
+                            {
+                              "title": "Eligible Leader Replica Node",
+                              "length_in_bytes": 0,
+                              "explanation_markdown": "A 4-byte integer representing an eligible leader replica node ID.\nHere, this field is empty.\n"
+                            }
+                          ]
                         },
                         {
                           "title": "Last Known ELR",
-                          "length_in_bytes": 1,
-                          "explanation_markdown": "The count of last known eligible leader replicas + 1, encoded as a varint.\nHere, it is 0x01 (1), indicating 0 last known eligible leader replicas.\n"
+                          "explanation_markdown": "An array of last known eligible leader replica node IDs for this partition.\n",
+                          "children": [
+                            {
+                              "title": "Array Length",
+                              "length_in_bytes": 1,
+                              "explanation_markdown": "The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                            },
+                            {
+                              "title": "Last Known ELR Node",
+                              "length_in_bytes": 0,
+                              "explanation_markdown": "A 4-byte integer representing a last known eligible leader replica node ID.\nHere, this field is empty.\n"
+                            }
+                          ]
                         },
                         {
                           "title": "Offline Replicas",
-                          "length_in_bytes": 1,
-                          "explanation_markdown": "The count of offline replicas + 1, encoded as a varint.\nHere, it is 0x01 (1), indicating 0 offline replicas.\n"
+                          "explanation_markdown": "An array of offline replica node IDs for this partition.\n",
+                          "children": [
+                            {
+                              "title": "Array Length",
+                              "length_in_bytes": 1,
+                              "explanation_markdown": "The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                            },
+                            {
+                              "title": "Offline Replica Node",
+                              "length_in_bytes": 0,
+                              "explanation_markdown": "A 4-byte integer representing a last known eligible leader replica node ID.\nHere, this field is empty.\n"
+                            }
+                          ]
                         },
                         {
                           "title": "Tag Buffer",
@@ -327,18 +360,51 @@ const generated: GeneratedData = {
                         },
                         {
                           "title": "Eligible Leader Replicas",
-                          "length_in_bytes": 1,
-                          "explanation_markdown": "The count of eligible leader replicas + 1, encoded as a varint.\nHere, it is 0x01 (1), indicating 0 eligible leader replicas.\n"
+                          "explanation_markdown": "An array of eligible leader replica node IDs for this partition.\n",
+                          "children": [
+                            {
+                              "title": "Array Length",
+                              "length_in_bytes": 1,
+                              "explanation_markdown": "The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                            },
+                            {
+                              "title": "Eligible Leader Replica Node",
+                              "length_in_bytes": 0,
+                              "explanation_markdown": "A 4-byte integer representing an eligible leader replica node ID.\nHere, this field is empty.\n"
+                            }
+                          ]
                         },
                         {
                           "title": "Last Known ELR",
-                          "length_in_bytes": 1,
-                          "explanation_markdown": "The count of last known eligible leader replicas + 1, encoded as a varint.\nHere, it is 0x01 (1), indicating 0 last known eligible leader replicas.\n"
+                          "explanation_markdown": "An array of last known eligible leader replica node IDs for this partition.\n",
+                          "children": [
+                            {
+                              "title": "Array Length",
+                              "length_in_bytes": 1,
+                              "explanation_markdown": "The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                            },
+                            {
+                              "title": "Last Known ELR Node",
+                              "length_in_bytes": 0,
+                              "explanation_markdown": "A 4-byte integer representing a last known eligible leader replica node ID.\nHere, this field is empty.\n"
+                            }
+                          ]
                         },
                         {
                           "title": "Offline Replicas",
-                          "length_in_bytes": 1,
-                          "explanation_markdown": "The count of offline replicas + 1, encoded as a varint.\nHere, it is 0x01 (1), indicating 0 offline replicas.\n"
+                          "explanation_markdown": "An array of offline replica node IDs for this partition.\n",
+                          "children": [
+                            {
+                              "title": "Array Length",
+                              "length_in_bytes": 1,
+                              "explanation_markdown": "The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                            },
+                            {
+                              "title": "Offline Replica Node",
+                              "length_in_bytes": 0,
+                              "explanation_markdown": "A 4-byte integer representing a last known eligible leader replica node ID.\nHere, this field is empty.\n"
+                            }
+                          ]
                         },
                         {
                           "title": "Tag Buffer",

--- a/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0.yml
+++ b/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0.yml
@@ -256,43 +256,28 @@ segments:
                               Here, it is 0x00000001 (1 in decimal).
                       - title: Eligible Leader Replicas
                         explanation_markdown: |
-                          An array of eligible leader replica node IDs for this partition.
+                          An array of eligible leader replica node IDs (int32) for this partition.
                         children:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
                               The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
-                          - title: Eligible Leader Replica Node
-                            length_in_bytes: 0
-                            explanation_markdown: |
-                              A 4-byte integer representing an eligible leader replica node ID.
-                              Here, this field is empty.
                       - title: Last Known ELR
                         explanation_markdown: |
-                          An array of last known eligible leader replica node IDs for this partition.
+                          An array of last known eligible leader replica node IDs (int32) for this partition.
                         children:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
                               The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
-                          - title: Last Known ELR Node
-                            length_in_bytes: 0
-                            explanation_markdown: |
-                              A 4-byte integer representing a last known eligible leader replica node ID.
-                              Here, this field is empty.
                       - title: Offline Replicas
                         explanation_markdown: |
-                          An array of offline replica node IDs for this partition.
+                          An array of offline replica node IDs (int32) for this partition.
                         children:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
                               The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
-                          - title: Offline Replica Node
-                            length_in_bytes: 0
-                            explanation_markdown: |
-                              A 4-byte integer representing a last known eligible leader replica node ID.
-                              Here, this field is empty.
                       - title: Tag Buffer
                         length_in_bytes: 1
                         explanation_markdown: |
@@ -349,43 +334,28 @@ segments:
                               Here, it is 0x00000001 (1 in decimal).
                       - title: Eligible Leader Replicas
                         explanation_markdown: |
-                          An array of eligible leader replica node IDs for this partition.
+                          An array of eligible leader replica node IDs (int32) for this partition.
                         children:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
                               The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
-                          - title: Eligible Leader Replica Node
-                            length_in_bytes: 0
-                            explanation_markdown: |
-                              A 4-byte integer representing an eligible leader replica node ID.
-                              Here, this field is empty.
                       - title: Last Known ELR
                         explanation_markdown: |
-                          An array of last known eligible leader replica node IDs for this partition.
+                          An array of last known eligible leader replica node IDs (int32) for this partition.
                         children:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
                               The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
-                          - title: Last Known ELR Node
-                            length_in_bytes: 0
-                            explanation_markdown: |
-                              A 4-byte integer representing a last known eligible leader replica node ID.
-                              Here, this field is empty.
                       - title: Offline Replicas
                         explanation_markdown: |
-                          An array of offline replica node IDs for this partition.
+                          An array of offline replica node IDs (int32) for this partition.
                         children:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
                               The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
-                          - title: Offline Replica Node
-                            length_in_bytes: 0
-                            explanation_markdown: |
-                              A 4-byte integer representing a last known eligible leader replica node ID.
-                              Here, this field is empty.
                       - title: Tag Buffer
                         length_in_bytes: 1
                         explanation_markdown: |

--- a/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0.yml
+++ b/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0.yml
@@ -255,20 +255,44 @@ segments:
                               A 4-byte integer representing an in-sync replica node ID.
                               Here, it is 0x00000001 (1 in decimal).
                       - title: Eligible Leader Replicas
-                        length_in_bytes: 1
                         explanation_markdown: |
-                          The count of eligible leader replicas + 1, encoded as a varint.
-                          Here, it is 0x01 (1), indicating 0 eligible leader replicas.
+                          An array of eligible leader replica node IDs for this partition.
+                        children:
+                          - title: Array Length
+                            length_in_bytes: 1
+                            explanation_markdown: |
+                              The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                          - title: Eligible Leader Replica Node
+                            length_in_bytes: 0
+                            explanation_markdown: |
+                              A 4-byte integer representing an eligible leader replica node ID.
+                              Here, this field is empty.
                       - title: Last Known ELR
-                        length_in_bytes: 1
                         explanation_markdown: |
-                          The count of last known eligible leader replicas + 1, encoded as a varint.
-                          Here, it is 0x01 (1), indicating 0 last known eligible leader replicas.
+                          An array of last known eligible leader replica node IDs for this partition.
+                        children:
+                          - title: Array Length
+                            length_in_bytes: 1
+                            explanation_markdown: |
+                              The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                          - title: Last Known ELR Node
+                            length_in_bytes: 0
+                            explanation_markdown: |
+                              A 4-byte integer representing a last known eligible leader replica node ID.
+                              Here, this field is empty.
                       - title: Offline Replicas
-                        length_in_bytes: 1
                         explanation_markdown: |
-                          The count of offline replicas + 1, encoded as a varint.
-                          Here, it is 0x01 (1), indicating 0 offline replicas.
+                          An array of offline replica node IDs for this partition.
+                        children:
+                          - title: Array Length
+                            length_in_bytes: 1
+                            explanation_markdown: |
+                              The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                          - title: Offline Replica Node
+                            length_in_bytes: 0
+                            explanation_markdown: |
+                              A 4-byte integer representing a last known eligible leader replica node ID.
+                              Here, this field is empty.
                       - title: Tag Buffer
                         length_in_bytes: 1
                         explanation_markdown: |
@@ -324,20 +348,44 @@ segments:
                               A 4-byte integer representing an in-sync replica node ID.
                               Here, it is 0x00000001 (1 in decimal).
                       - title: Eligible Leader Replicas
-                        length_in_bytes: 1
                         explanation_markdown: |
-                          The count of eligible leader replicas + 1, encoded as a varint.
-                          Here, it is 0x01 (1), indicating 0 eligible leader replicas.
+                          An array of eligible leader replica node IDs for this partition.
+                        children:
+                          - title: Array Length
+                            length_in_bytes: 1
+                            explanation_markdown: |
+                              The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                          - title: Eligible Leader Replica Node
+                            length_in_bytes: 0
+                            explanation_markdown: |
+                              A 4-byte integer representing an eligible leader replica node ID.
+                              Here, this field is empty.
                       - title: Last Known ELR
-                        length_in_bytes: 1
                         explanation_markdown: |
-                          The count of last known eligible leader replicas + 1, encoded as a varint.
-                          Here, it is 0x01 (1), indicating 0 last known eligible leader replicas.
+                          An array of last known eligible leader replica node IDs for this partition.
+                        children:
+                          - title: Array Length
+                            length_in_bytes: 1
+                            explanation_markdown: |
+                              The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                          - title: Last Known ELR Node
+                            length_in_bytes: 0
+                            explanation_markdown: |
+                              A 4-byte integer representing a last known eligible leader replica node ID.
+                              Here, this field is empty.
                       - title: Offline Replicas
-                        length_in_bytes: 1
                         explanation_markdown: |
-                          The count of offline replicas + 1, encoded as a varint.
-                          Here, it is 0x01 (1), indicating 0 offline replicas.
+                          An array of offline replica node IDs for this partition.
+                        children:
+                          - title: Array Length
+                            length_in_bytes: 1
+                            explanation_markdown: |
+                              The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                          - title: Offline Replica Node
+                            length_in_bytes: 0
+                            explanation_markdown: |
+                              A 4-byte integer representing a last known eligible leader replica node ID.
+                              Here, this field is empty.
                       - title: Tag Buffer
                         length_in_bytes: 1
                         explanation_markdown: |


### PR DESCRIPTION
This pull request fixes the data structures used for topic partition response in the code. The changes ensure that the arrays for eligible leader replicas, last known ELR, and offline replicas are correctly handled and encoded. The length of these arrays is now properly calculated and encoded as varints. Additionally, the pull request includes empty fields for the eligible leader replica nodes, last known ELR nodes, and offline replica nodes, indicating that there are no nodes present in these arrays.