### PR TITLE
Add APIVersions response to binspec

### DIFF
--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-unsupported-version.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-unsupported-version.ts
@@ -34,7 +34,7 @@ const generated: GeneratedData = {
     },
     {
       "title": "Response Header (v0)",
-      "explanation_markdown": "The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.\n",
+      "explanation_markdown": "The Response Header structure is common across all Kafka responses.\n\nAPIVersions uses the older version of Response Headers (v0), to keep this API compatible across all clients.\n\nYou can read more about this [here](https://github.com/apache/kafka/blob/654ebe10f4a5c31e449b2a2ef6c284254ed7dceb/clients/src/main/resources/common/message/ApiVersionsResponse.json#L24)\n\nv0 headers and v1 headers are nearly identical, the only difference is that v1 contains an additional `tag_buffer` field at the end.\n",
       "children": [
         {
           "title": "Correlation ID",
@@ -50,11 +50,11 @@ const generated: GeneratedData = {
         {
           "title": "Error Code",
           "length_in_bytes": 2,
-          "explanation_markdown": "A 2-byte integer representing the error code for this response.\n\nHere, it is 0x0023 (35), which corresponds to UNSUPPORTED_VERSION.\n"
+          "explanation_markdown": "A 2-byte integer representing the error code for this response.\n\nHere, it is 0x0023 (35), which corresponds to UNSUPPORTED_VERSION.\nYou can find all the error codes [here](https://kafka.apache.org/protocol.html#protocol_error_codes)\n"
         },
         {
           "title": "API Versions Array",
-          "explanation_markdown": "An array of API Versions described in the response.\n\nThis array is encoded as an `ARRAY`, which starts with a int32 corresponding to the length of the array, followed by each element.\n",
+          "explanation_markdown": "An array of API Versions supported by this Kafka instance.\n\nThis array is encoded as an `ARRAY` type, which starts with a int32 corresponding to the length of the array, followed by each element.\n\nNote: In all versions except for v0, this value is encoded as a `COMPACT_ARRAY`. In v0, it is encoded as a `ARRAY`.\n",
           "children": [
             {
               "title": "Array Length",
@@ -73,7 +73,7 @@ const generated: GeneratedData = {
                 {
                   "title": "Min Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API. \nHere, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.\n"
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API.\nHere, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.\n"
                 },
                 {
                   "title": "Max Supported API Version",

--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-unsupported-version.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-unsupported-version.ts
@@ -1,0 +1,92 @@
+// GENERATED FILE - DO NOT EDIT DIRECTLY - RUN make generate_data_from_yaml INSTEAD
+import type { GeneratedData } from "binspec-visualizer/lib/format";
+
+const generated: GeneratedData = {
+  "name": "Kafka API Versions Response (v4)",
+  "slug": "kafka-api-versions-Response-v4",
+  "data": [
+    0,
+    0,
+    0,
+    16,
+    0,
+    0,
+    0,
+    7,
+    0,
+    35,
+    0,
+    0,
+    0,
+    1,
+    0,
+    18,
+    0,
+    0,
+    0,
+    4
+  ],
+  "segments": [
+    {
+      "title": "Message Size",
+      "length_in_bytes": 4,
+      "explanation_markdown": "Message Size is a 4-byte big-endian integer indicating the size of the rest of the message. All Kafka responses start with this field.\n\nIn this case, the value is 0x10 (16 in decimal) indicating that the rest of the message is 16 bytes long.\n"
+    },
+    {
+      "title": "Response Header (v0)",
+      "explanation_markdown": "The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.\n",
+      "children": [
+        {
+          "title": "Correlation ID",
+          "length_in_bytes": 4,
+          "explanation_markdown": "The Correlation ID is a 4-byte integer that matches the ID sent in the corresponding request.\n\nHere, it is 0x07 (7).\n"
+        }
+      ]
+    },
+    {
+      "title": "API Versions Response Body (v0)",
+      "explanation_markdown": "The response body contains fields specific to the API Versions response.\n",
+      "children": [
+        {
+          "title": "Error Code",
+          "length_in_bytes": 2,
+          "explanation_markdown": "A 2-byte integer representing the error code for this response.\n\nHere, it is 0x0023 (35), which corresponds to UNSUPPORTED_VERSION.\n"
+        },
+        {
+          "title": "API Versions Array",
+          "explanation_markdown": "An array of API Versions described in the response.\n\nThis array is encoded as an `ARRAY`, which starts with a int32 corresponding to the length of the array, followed by each element.\n",
+          "children": [
+            {
+              "title": "Array Length",
+              "length_in_bytes": 4,
+              "explanation_markdown": "The length of the API Versions array, encoded as a int32. Here, it is 0x01 (1), meaning that the array length is 1.\n"
+            },
+            {
+              "title": "API Version #1",
+              "explanation_markdown": "A single API Version in the array.\n",
+              "children": [
+                {
+                  "title": "API Key",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x0012 (18), which corresponds to the API Versions API.\n"
+                },
+                {
+                  "title": "Min Supported API Version",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API. \nHere, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.\n"
+                },
+                {
+                  "title": "Max Supported API Version",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.\n"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+export default generated;

--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-unsupported-version.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-unsupported-version.ts
@@ -2,8 +2,8 @@
 import type { GeneratedData } from "binspec-visualizer/lib/format";
 
 const generated: GeneratedData = {
-  "name": "Kafka API Versions Response (v4)",
-  "slug": "kafka-api-versions-Response-v4",
+  "name": "Kafka API Versions Error Response (v0)",
+  "slug": "kafka-api-versions-response-unsupported-version",
   "data": [
     0,
     0,

--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-v4.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-v4.ts
@@ -51,7 +51,7 @@ const generated: GeneratedData = {
     },
     {
       "title": "Response Header (v0)",
-      "explanation_markdown": "The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.\n",
+      "explanation_markdown": "The Response Header structure is common across all Kafka responses.\n\nAPIVersions uses the older version of Response Headers (v0), to keep this API compatible across all clients.\n\nYou can read more about this [here](https://github.com/apache/kafka/blob/654ebe10f4a5c31e449b2a2ef6c284254ed7dceb/clients/src/main/resources/common/message/ApiVersionsResponse.json#L24)\n\nv0 headers and v1 headers are nearly identical, the only difference is that v1 contains an additional `tag_buffer` field at the end.\n",
       "children": [
         {
           "title": "Correlation ID",
@@ -85,17 +85,17 @@ const generated: GeneratedData = {
                 {
                   "title": "API Key",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x0001 (1), which corresponds to the Fetch API.\n"
+                  "explanation_markdown": "A 2-byte integer representing the API Key for this entry.\n\nHere, it is 0x0001 (1), which corresponds to the Fetch API.\n"
                 },
                 {
                   "title": "Min Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API. \nHere, it is 0x0000 (0), which means that the Fetch API supports versions 0 and up.\n"
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this entry. \nHere, it is 0x0000 (0), which means that the Fetch API supports versions 0 and up.\n"
                 },
                 {
                   "title": "Max Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0011 (17), which means that the Fetch API supports versions upto 17.\n"
+                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this entry.\nHere, it is 0x0011 (17), which means that the Fetch API supports versions upto 17.\n"
                 },
                 {
                   "title": "Tag Buffer",
@@ -111,17 +111,17 @@ const generated: GeneratedData = {
                 {
                   "title": "API Key",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x0012 (18), which corresponds to the API Versions API.\n"
+                  "explanation_markdown": "A 2-byte integer representing the API Key for this entry.\n\nHere, it is 0x0012 (18), which corresponds to the APIVersions API.\n"
                 },
                 {
                   "title": "Min Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API. \nHere, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.\n"
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this entry. \nHere, it is 0x0000 (0), which means that the APIVersions API supports versions 0 and up.\n"
                 },
                 {
                   "title": "Max Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.\n"
+                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this entry.\nHere, it is 0x0004 (4), which means that the APIVersions API supports versions upto 4.\n"
                 },
                 {
                   "title": "Tag Buffer",
@@ -137,17 +137,17 @@ const generated: GeneratedData = {
                 {
                   "title": "API Key",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x004b (75), which corresponds to the DescribeTopicPartitions API.\n"
+                  "explanation_markdown": "A 2-byte integer representing the API Key for this entry.\n\nHere, it is 0x004b (75), which corresponds to the DescribeTopicPartitions API.\n"
                 },
                 {
                   "title": "Min Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API. \nHere, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions 0 and up.\n"
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this entry. \nHere, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions 0 and up.\n"
                 },
                 {
                   "title": "Max Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions upto 0.\n"
+                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this entry.\nHere, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions upto 0.\n"
                 },
                 {
                   "title": "Tag Buffer",

--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-v4.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-v4.ts
@@ -1,0 +1,176 @@
+// GENERATED FILE - DO NOT EDIT DIRECTLY - RUN make generate_data_from_yaml INSTEAD
+import type { GeneratedData } from "binspec-visualizer/lib/format";
+
+const generated: GeneratedData = {
+  "name": "Kafka API Versions Response (v4)",
+  "slug": "kafka-api-versions-Response-v4",
+  "data": [
+    0,
+    0,
+    0,
+    33,
+    0,
+    0,
+    0,
+    7,
+    0,
+    0,
+    4,
+    0,
+    1,
+    0,
+    0,
+    0,
+    17,
+    0,
+    0,
+    18,
+    0,
+    0,
+    0,
+    4,
+    0,
+    0,
+    75,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "segments": [
+    {
+      "title": "Message Size",
+      "length_in_bytes": 4,
+      "explanation_markdown": "Message Size is a 4-byte big-endian integer indicating the size of the rest of the message. All Kafka responses start with this field.\n\nIn this case, the value is 0x21 (33 in decimal) indicating that the rest of the message is 33 bytes long.\n"
+    },
+    {
+      "title": "Response Header (v0)",
+      "explanation_markdown": "The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.\n",
+      "children": [
+        {
+          "title": "Correlation ID",
+          "length_in_bytes": 4,
+          "explanation_markdown": "The Correlation ID is a 4-byte integer that matches the ID sent in the corresponding request.\n\nHere, it is 0x07 (7).\n"
+        }
+      ]
+    },
+    {
+      "title": "API Versions Response Body (v4)",
+      "explanation_markdown": "The response body contains fields specific to the API Versions response.\n",
+      "children": [
+        {
+          "title": "Error Code",
+          "length_in_bytes": 2,
+          "explanation_markdown": "A 2-byte integer representing the error code for this response.\n\nHere, it is 0x0000 (0), which corresponds to NO_ERROR.\n"
+        },
+        {
+          "title": "API Versions Array",
+          "explanation_markdown": "An array of API Versions described in the response.\n\nThis array is encoded as a `COMPACT_ARRAY`, which starts with a varint corresponding to the length of the array + 1, followed by each element.\n",
+          "children": [
+            {
+              "title": "Array Length",
+              "length_in_bytes": 1,
+              "explanation_markdown": "The length of the API Versions array + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the array length is 3.\n"
+            },
+            {
+              "title": "API Version #1",
+              "explanation_markdown": "A single API Version in the array.\n",
+              "children": [
+                {
+                  "title": "API Key",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x0001 (1), which corresponds to the Fetch API.\n"
+                },
+                {
+                  "title": "Min Supported API Version",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API. \nHere, it is 0x0000 (0), which means that the Fetch API supports versions 0 and up.\n"
+                },
+                {
+                  "title": "Max Supported API Version",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0011 (17), which means that the Fetch API supports versions upto 17.\n"
+                },
+                {
+                  "title": "Tag Buffer",
+                  "length_in_bytes": 1,
+                  "explanation_markdown": "An empty tagged field array for the response, represented by a single byte of value 0x00.\n"
+                }
+              ]
+            },
+            {
+              "title": "API Version #2",
+              "explanation_markdown": "A single API Version in the array.\n",
+              "children": [
+                {
+                  "title": "API Key",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x0012 (18), which corresponds to the API Versions API.\n"
+                },
+                {
+                  "title": "Min Supported API Version",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API. \nHere, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.\n"
+                },
+                {
+                  "title": "Max Supported API Version",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.\n"
+                },
+                {
+                  "title": "Tag Buffer",
+                  "length_in_bytes": 1,
+                  "explanation_markdown": "An empty tagged field array for the response, represented by a single byte of value 0x00.\n"
+                }
+              ]
+            },
+            {
+              "title": "API Version #3",
+              "explanation_markdown": "A single API Version in the array.\n",
+              "children": [
+                {
+                  "title": "API Key",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x004b (75), which corresponds to the DescribeTopicPartitions API.\n"
+                },
+                {
+                  "title": "Min Supported API Version",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API. \nHere, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions 0 and up.\n"
+                },
+                {
+                  "title": "Max Supported API Version",
+                  "length_in_bytes": 2,
+                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions upto 0.\n"
+                },
+                {
+                  "title": "Tag Buffer",
+                  "length_in_bytes": 1,
+                  "explanation_markdown": "An empty tagged field array for the response, represented by a single byte of value 0x00.\n"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Throttle Time",
+          "length_in_bytes": 4,
+          "explanation_markdown": "A 4-byte integer that represents the duration in milliseconds for which the request was throttled due to quota violation.\n\nHere, it is 0x00000000 (0 in decimal), indicating no throttling.\n"
+        },
+        {
+          "title": "Tag Buffer",
+          "length_in_bytes": 1,
+          "explanation_markdown": "An empty tagged field array, represented by a single byte of value 0x00.\n"
+        }
+      ]
+    }
+  ]
+}
+
+export default generated;

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -28,7 +28,7 @@ segments:
     explanation_markdown: |
       Message Size is a 4-byte big-endian integer indicating the size of the rest of the message. All Kafka responses start with this field.
 
-      In this case, the value is 0x21 (33 in decimal) indicating that the rest of the message is 33 bytes long.
+      In this case, the value is 0x10 (16 in decimal) indicating that the rest of the message is 16 bytes long.
   - title: Response Header (v0)
     explanation_markdown: |
       The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.
@@ -39,7 +39,7 @@ segments:
           The Correlation ID is a 4-byte integer that matches the ID sent in the corresponding request.
 
           Here, it is 0x07 (7).
-  - title: API Versions Response Body (v4)
+  - title: API Versions Response Body (v0)
     explanation_markdown: |
       The response body contains fields specific to the API Versions response.
     children:
@@ -48,42 +48,18 @@ segments:
         explanation_markdown: |
           A 2-byte integer representing the error code for this response.
 
-          Here, it is 0x0000 (0), which corresponds to NO_ERROR.
+          Here, it is 0x0023 (35), which corresponds to UNSUPPORTED_VERSION.
       - title: API Versions Array
         explanation_markdown: |
           An array of API Versions described in the response.
 
-          This array is encoded as a `COMPACT_ARRAY`, which starts with a varint corresponding to the length of the array + 1, followed by each element.
+          This array is encoded as an `ARRAY`, which starts with a int32 corresponding to the length of the array, followed by each element.
         children:
           - title: Array Length
-            length_in_bytes: 1
+            length_in_bytes: 4
             explanation_markdown: |
-              The length of the API Versions array + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the array length is 3.
+              The length of the API Versions array, encoded as a int32. Here, it is 0x01 (1), meaning that the array length is 1.
           - title: "API Version #1"
-            explanation_markdown: |
-              A single API Version in the array.
-            children:
-              - title: API Key
-                length_in_bytes: 2
-                explanation_markdown: |
-                  A 2-byte integer representing the API Key for this API Version.
-
-                  Here, it is 0x0001 (1), which corresponds to the Fetch API.
-              - title: Min Supported API Version
-                length_in_bytes: 2
-                explanation_markdown: |
-                  A 2-byte integer representing the minimum supported API Version for this API. 
-                  Here, it is 0x0000 (0), which means that the Fetch API supports versions 0 and up.
-              - title: Max Supported API Version
-                length_in_bytes: 2
-                explanation_markdown: |
-                  A 2-byte integer representing the maximum supported API Version for this API.
-                  Here, it is 0x0011 (17), which means that the Fetch API supports versions upto 17.
-              - title: Tag Buffer
-                length_in_bytes: 1
-                explanation_markdown: |
-                  An empty tagged field array for the response, represented by a single byte of value 0x00.
-          - title: "API Version #2"
             explanation_markdown: |
               A single API Version in the array.
             children:
@@ -103,41 +79,3 @@ segments:
                 explanation_markdown: |
                   A 2-byte integer representing the maximum supported API Version for this API.
                   Here, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.
-              - title: Tag Buffer
-                length_in_bytes: 1
-                explanation_markdown: |
-                  An empty tagged field array for the response, represented by a single byte of value 0x00.
-          - title: "API Version #3"
-            explanation_markdown: |
-              A single API Version in the array.
-            children:
-              - title: API Key
-                length_in_bytes: 2
-                explanation_markdown: |
-                  A 2-byte integer representing the API Key for this API Version.
-
-                  Here, it is 0x004b (75), which corresponds to the DescribeTopicPartitions API.
-              - title: Min Supported API Version
-                length_in_bytes: 2
-                explanation_markdown: |
-                  A 2-byte integer representing the minimum supported API Version for this API. 
-                  Here, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions 0 and up.
-              - title: Max Supported API Version
-                length_in_bytes: 2
-                explanation_markdown: |
-                  A 2-byte integer representing the maximum supported API Version for this API.
-                  Here, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions upto 0.
-              - title: Tag Buffer
-                length_in_bytes: 1
-                explanation_markdown: |
-                  An empty tagged field array for the response, represented by a single byte of value 0x00.
-      - title: Throttle Time
-        length_in_bytes: 4
-        explanation_markdown: |
-          A 4-byte integer that represents the duration in milliseconds for which the request was throttled due to quota violation.
-
-          Here, it is 0x00000000 (0 in decimal), indicating no throttling.
-      - title: Tag Buffer
-        length_in_bytes: 1
-        explanation_markdown: |
-          An empty tagged field array, represented by a single byte of value 0x00.

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -1,5 +1,5 @@
-name: Kafka API Versions Response (v4)
-slug: kafka-api-versions-Response-v4
+name: Kafka API Versions Error Response (v0)
+slug: kafka-api-versions-response-unsupported-version
 data:
   - 0x00 # Message length (4 bytes, 0x10 in hex, 16 in decimal)
   - 0x00

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -1,0 +1,143 @@
+name: Kafka API Versions Response (v4)
+slug: kafka-api-versions-Response-v4
+data:
+  - 0x00 # Message length (4 bytes, 0x10 in hex, 16 in decimal)
+  - 0x00
+  - 0x00
+  - 0x10
+  - 0x00 # Correlation ID (4 bytes, 0x07 in hex, 7 in decimal)
+  - 0x00
+  - 0x00
+  - 0x07
+  - 0x00 # Error code (2 bytes, 0x23 in hex, 35 in decimal)
+  - 0x23
+  - 0x00 # Number of APIVersions Keys (4 byte, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00 
+  - 0x01 
+  - 0x00 # API Key (2 bytes, 0x0012 in hex, 18 in decimal (APIVersions API))
+  - 0x12 
+  - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
+  - 0x00
+  - 0x00 # Max supported APIVersion (2 bytes, 0x0004 in hex, 4 in decimal)
+  - 0x04 
+
+segments:
+  - title: Message Size
+    length_in_bytes: 4
+    explanation_markdown: |
+      Message Size is a 4-byte big-endian integer indicating the size of the rest of the message. All Kafka responses start with this field.
+
+      In this case, the value is 0x21 (33 in decimal) indicating that the rest of the message is 33 bytes long.
+  - title: Response Header (v0)
+    explanation_markdown: |
+      The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.
+    children:
+      - title: Correlation ID
+        length_in_bytes: 4
+        explanation_markdown: |
+          The Correlation ID is a 4-byte integer that matches the ID sent in the corresponding request.
+
+          Here, it is 0x07 (7).
+  - title: API Versions Response Body (v4)
+    explanation_markdown: |
+      The response body contains fields specific to the API Versions response.
+    children:
+      - title: Error Code
+        length_in_bytes: 2
+        explanation_markdown: |
+          A 2-byte integer representing the error code for this response.
+
+          Here, it is 0x0000 (0), which corresponds to NO_ERROR.
+      - title: API Versions Array
+        explanation_markdown: |
+          An array of API Versions described in the response.
+
+          This array is encoded as a `COMPACT_ARRAY`, which starts with a varint corresponding to the length of the array + 1, followed by each element.
+        children:
+          - title: Array Length
+            length_in_bytes: 1
+            explanation_markdown: |
+              The length of the API Versions array + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the array length is 3.
+          - title: "API Version #1"
+            explanation_markdown: |
+              A single API Version in the array.
+            children:
+              - title: API Key
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the API Key for this API Version.
+
+                  Here, it is 0x0001 (1), which corresponds to the Fetch API.
+              - title: Min Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  Here, it is 0x0000 (0), which means that the Fetch API supports versions 0 and up.
+              - title: Max Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the maximum supported API Version for this API.
+                  Here, it is 0x0011 (17), which means that the Fetch API supports versions upto 17.
+              - title: Tag Buffer
+                length_in_bytes: 1
+                explanation_markdown: |
+                  An empty tagged field array for the response, represented by a single byte of value 0x00.
+          - title: "API Version #2"
+            explanation_markdown: |
+              A single API Version in the array.
+            children:
+              - title: API Key
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the API Key for this API Version.
+
+                  Here, it is 0x0012 (18), which corresponds to the API Versions API.
+              - title: Min Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  Here, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.
+              - title: Max Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the maximum supported API Version for this API.
+                  Here, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.
+              - title: Tag Buffer
+                length_in_bytes: 1
+                explanation_markdown: |
+                  An empty tagged field array for the response, represented by a single byte of value 0x00.
+          - title: "API Version #3"
+            explanation_markdown: |
+              A single API Version in the array.
+            children:
+              - title: API Key
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the API Key for this API Version.
+
+                  Here, it is 0x004b (75), which corresponds to the DescribeTopicPartitions API.
+              - title: Min Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  Here, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions 0 and up.
+              - title: Max Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the maximum supported API Version for this API.
+                  Here, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions upto 0.
+              - title: Tag Buffer
+                length_in_bytes: 1
+                explanation_markdown: |
+                  An empty tagged field array for the response, represented by a single byte of value 0x00.
+      - title: Throttle Time
+        length_in_bytes: 4
+        explanation_markdown: |
+          A 4-byte integer that represents the duration in milliseconds for which the request was throttled due to quota violation.
+
+          Here, it is 0x00000000 (0 in decimal), indicating no throttling.
+      - title: Tag Buffer
+        length_in_bytes: 1
+        explanation_markdown: |
+          An empty tagged field array, represented by a single byte of value 0x00.

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -62,6 +62,8 @@ segments:
           An array of API Versions supported by this Kafka instance.
 
           This array is encoded as an `ARRAY` type, which starts with a int32 corresponding to the length of the array, followed by each element.
+
+          Note: In all versions except for v0, this value is encoded as a `COMPACT_ARRAY`. In v0, it is encoded as a `ARRAY`.
         children:
           - title: Array Length
             length_in_bytes: 4

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -33,11 +33,11 @@ segments:
     explanation_markdown: |
       The Response Header structure is common across all Kafka responses.
 
-      Most Kafka responses use Response Header (v1), but when APIVersions is called with an unsupported version, it uses v0.
+      APIVersions uses the older version of Response Headers (v0), to keep this API compatible across all clients.
 
-      <!-- TODO: Add a link that explains this, can be to source code or KIP -->
+      You can read more about this [here](https://github.com/apache/kafka/blob/654ebe10f4a5c31e449b2a2ef6c284254ed7dceb/clients/src/main/resources/common/message/ApiVersionsResponse.json#L24)
 
-      v0 and v1 are nearly identical, the only difference is that v1 contains an additional `tag_buffer` field at the end.
+      v0 headers and v1 headers are nearly identical, the only difference is that v1 contains an additional `tag_buffer` field at the end.
     children:
       - title: Correlation ID
         length_in_bytes: 4
@@ -55,8 +55,7 @@ segments:
           A 2-byte integer representing the error code for this response.
 
           Here, it is 0x0023 (35), which corresponds to UNSUPPORTED_VERSION.
-
-          <!-- TODO: Add a link to errors codes in docs -->
+          You can find all the error codes [here](https://kafka.apache.org/protocol.html#protocol_error_codes)
       - title: API Versions Array
         explanation_markdown: |
           An array of API Versions supported by this Kafka instance.

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -59,9 +59,9 @@ segments:
           <!-- TODO: Add a link to errors codes in docs -->
       - title: API Versions Array
         explanation_markdown: |
-          An array of API Versions described in the response.
+          An array of API Versions supported by this Kafka instance.
 
-          This array is encoded as an `ARRAY`, which starts with a int32 corresponding to the length of the array, followed by each element.
+          This array is encoded as an `ARRAY` type, which starts with a int32 corresponding to the length of the array, followed by each element.
         children:
           - title: Array Length
             length_in_bytes: 4

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -55,6 +55,8 @@ segments:
           A 2-byte integer representing the error code for this response.
 
           Here, it is 0x0023 (35), which corresponds to UNSUPPORTED_VERSION.
+
+          <!-- TODO: Add a link to errors codes in docs -->
       - title: API Versions Array
         explanation_markdown: |
           An array of API Versions described in the response.

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -13,14 +13,14 @@ data:
   - 0x23
   - 0x00 # Number of APIVersions Keys (4 byte, 0x01 in hex, 1 in decimal)
   - 0x00
-  - 0x00 
-  - 0x01 
+  - 0x00
+  - 0x01
   - 0x00 # API Key (2 bytes, 0x0012 in hex, 18 in decimal (APIVersions API))
-  - 0x12 
+  - 0x12
   - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
   - 0x00
   - 0x00 # Max supported APIVersion (2 bytes, 0x0004 in hex, 4 in decimal)
-  - 0x04 
+  - 0x04
 
 segments:
   - title: Message Size
@@ -31,7 +31,13 @@ segments:
       In this case, the value is 0x10 (16 in decimal) indicating that the rest of the message is 16 bytes long.
   - title: Response Header (v0)
     explanation_markdown: |
-      The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.
+      The Response Header structure is common across all Kafka responses.
+
+      Most Kafka responses use Response Header (v1), but when APIVersions is called with an unsupported version, it uses v0.
+
+      <!-- TODO: Add a link that explains this, can be to source code or KIP -->
+
+      v0 and v1 are nearly identical, the only difference is that v1 contains an additional `tag_buffer` field at the end.
     children:
       - title: Correlation ID
         length_in_bytes: 4
@@ -72,7 +78,7 @@ segments:
               - title: Min Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  A 2-byte integer representing the minimum supported API Version for this API.
                   Here, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.
               - title: Max Supported API Version
                 length_in_bytes: 2

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
@@ -1,0 +1,58 @@
+name: Kafka API Versions Response (v4)
+slug: kafka-api-versions-Response-v4
+data:
+  - 0x00 # Message length (4 bytes, 0x21 in hex, 33 in decimal)
+  - 0x00
+  - 0x00
+  - 0x21
+  - 0x00 # Correlation ID (4 bytes, 0x07 in hex, 7 in decimal)
+  - 0x00
+  - 0x00
+  - 0x07
+  - 0x00 # Error code (2 bytes, 0x00 in hex, 0 in decimal)
+  - 0x00
+  - 0x03 # Number of APIVersions Keys (1 byte, 0x03 in hex, 3 in decimal)
+  - 0x00 # API Key (2 bytes, 0x0001 in hex, 1 in decimal (Fetch API))
+  - 0x01 
+  - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
+  - 0x00
+  - 0x00 # Max supported APIVersion (2 bytes, 0x0011 in hex, 17 in decimal)
+  - 0x11 
+  - 0x00 # Empty tagged field array (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # API Key (2 bytes, 0x0012 in hex, 18 in decimal (APIVersions API))
+  - 0x12 
+  - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
+  - 0x00
+  - 0x00 # Max supported APIVersion (2 bytes, 0x0004 in hex, 4 in decimal)
+  - 0x04 
+  - 0x00 # Empty tagged field array (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # API Key (2 bytes, 0x004b in hex, 75 in decimal (DescribeTopicPartitions API))
+  - 0x4b 
+  - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
+  - 0x00
+  - 0x00 # Max supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
+  - 0x00 
+  - 0x00 # Empty tagged field array (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # Throttle time (4 bytes, 0x00000000 in hex, 0 in decimal)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00 # Empty tagged field array (1 byte, 0x00 in hex, 0 in decimal)
+
+segments:
+  - title: Message Size
+    length_in_bytes: 4
+    explanation_markdown: |
+      Message Size is a 4-byte big-endian integer indicating the size of the rest of the message. All Kafka responses start with this field.
+
+      In this case, the value is 0x21 (33 in decimal) indicating that the rest of the message is 33 bytes long.
+  - title: Response Header (v0)
+    explanation_markdown: |
+      The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.
+    children:
+      - title: Correlation ID
+        length_in_bytes: 4
+        explanation_markdown: |
+          The Correlation ID is a 4-byte integer that matches the ID sent in the corresponding request.
+
+          Here, it is 0x07 (7).

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
@@ -11,7 +11,7 @@ data:
   - 0x07
   - 0x00 # Error code (2 bytes, 0x00 in hex, 0 in decimal)
   - 0x00
-  - 0x03 # Number of APIVersions Keys (1 byte, 0x03 in hex, 3 in decimal)
+  - 0x04 # Number of APIVersions Keys (1 byte, 0x04 in hex, 4 in decimal)
   - 0x00 # API Key (2 bytes, 0x0001 in hex, 1 in decimal (Fetch API))
   - 0x01 
   - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
@@ -56,3 +56,105 @@ segments:
           The Correlation ID is a 4-byte integer that matches the ID sent in the corresponding request.
 
           Here, it is 0x07 (7).
+  - title: API Versions Response Body (v4)
+    explanation_markdown: |
+      The response body contains fields specific to the API Versions response.
+    children:
+      - title: Error Code
+        length_in_bytes: 2
+        explanation_markdown: |
+          A 2-byte integer representing the error code for this response.
+
+          Here, it is 0x0000 (0), which corresponds to NO_ERROR.
+      - title: API Versions Array
+        explanation_markdown: |
+          An array of API Versions described in the response.
+
+          This array is encoded as a `COMPACT_ARRAY`, which starts with a varint corresponding to the length of the array + 1, followed by each element.
+        children:
+          - title: Array Length
+            length_in_bytes: 1
+            explanation_markdown: |
+              The length of the API Versions array + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the array length is 3.
+          - title: "API Version #1"
+            explanation_markdown: |
+              A single API Version in the array.
+            children:
+              - title: API Key
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the API Key for this API Version.
+
+                  Here, it is 0x0001 (1), which corresponds to the Fetch API.
+              - title: Min Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  Here, it is 0x0000 (0), which means that the Fetch API supports versions 0 and up.
+              - title: Max Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the maximum supported API Version for this API.
+                  Here, it is 0x0011 (17), which means that the Fetch API supports versions upto 17.
+              - title: Tag Buffer
+                length_in_bytes: 1
+                explanation_markdown: |
+                  An empty tagged field array for the response, represented by a single byte of value 0x00.
+          - title: "API Version #2"
+            explanation_markdown: |
+              A single API Version in the array.
+            children:
+              - title: API Key
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the API Key for this API Version.
+
+                  Here, it is 0x0012 (18), which corresponds to the API Versions API.
+              - title: Min Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  Here, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.
+              - title: Max Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the maximum supported API Version for this API.
+                  Here, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.
+              - title: Tag Buffer
+                length_in_bytes: 1
+                explanation_markdown: |
+                  An empty tagged field array for the response, represented by a single byte of value 0x00.
+          - title: "API Version #3"
+            explanation_markdown: |
+              A single API Version in the array.
+            children:
+              - title: API Key
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the API Key for this API Version.
+
+                  Here, it is 0x004b (75), which corresponds to the DescribeTopicPartitions API.
+              - title: Min Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  Here, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions 0 and up.
+              - title: Max Supported API Version
+                length_in_bytes: 2
+                explanation_markdown: |
+                  A 2-byte integer representing the maximum supported API Version for this API.
+                  Here, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions upto 0.
+              - title: Tag Buffer
+                length_in_bytes: 1
+                explanation_markdown: |
+                  An empty tagged field array for the response, represented by a single byte of value 0x00.
+      - title: Throttle Time
+        length_in_bytes: 4
+        explanation_markdown: |
+          A 4-byte integer that represents the duration in milliseconds for which the request was throttled due to quota violation.
+
+          Here, it is 0x00000000 (0 in decimal), indicating no throttling.
+      - title: Tag Buffer
+        length_in_bytes: 1
+        explanation_markdown: |
+          An empty tagged field array, represented by a single byte of value 0x00.

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
@@ -48,7 +48,13 @@ segments:
       In this case, the value is 0x21 (33 in decimal) indicating that the rest of the message is 33 bytes long.
   - title: Response Header (v0)
     explanation_markdown: |
-      The Response Header structure is common across all Kafka responses. APIVersions uses the older version of Response Headers, to keep this API compatible across all clients.
+      The Response Header structure is common across all Kafka responses.
+
+      APIVersions uses the older version of Response Headers (v0), to keep this API compatible across all clients.
+
+      You can read more about this [here](https://github.com/apache/kafka/blob/654ebe10f4a5c31e449b2a2ef6c284254ed7dceb/clients/src/main/resources/common/message/ApiVersionsResponse.json#L24)
+
+      v0 headers and v1 headers are nearly identical, the only difference is that v1 contains an additional `tag_buffer` field at the end.
     children:
       - title: Correlation ID
         length_in_bytes: 4
@@ -83,18 +89,18 @@ segments:
               - title: API Key
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the API Key for this API Version.
+                  A 2-byte integer representing the API Key for this entry.
 
                   Here, it is 0x0001 (1), which corresponds to the Fetch API.
               - title: Min Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  A 2-byte integer representing the minimum supported API Version for this entry. 
                   Here, it is 0x0000 (0), which means that the Fetch API supports versions 0 and up.
               - title: Max Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the maximum supported API Version for this API.
+                  A 2-byte integer representing the maximum supported API Version for this entry.
                   Here, it is 0x0011 (17), which means that the Fetch API supports versions upto 17.
               - title: Tag Buffer
                 length_in_bytes: 1
@@ -107,19 +113,19 @@ segments:
               - title: API Key
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the API Key for this API Version.
+                  A 2-byte integer representing the API Key for this entry.
 
-                  Here, it is 0x0012 (18), which corresponds to the API Versions API.
+                  Here, it is 0x0012 (18), which corresponds to the APIVersions API.
               - title: Min Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the minimum supported API Version for this API. 
-                  Here, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.
+                  A 2-byte integer representing the minimum supported API Version for this entry. 
+                  Here, it is 0x0000 (0), which means that the APIVersions API supports versions 0 and up.
               - title: Max Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the maximum supported API Version for this API.
-                  Here, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.
+                  A 2-byte integer representing the maximum supported API Version for this entry.
+                  Here, it is 0x0004 (4), which means that the APIVersions API supports versions upto 4.
               - title: Tag Buffer
                 length_in_bytes: 1
                 explanation_markdown: |
@@ -131,18 +137,18 @@ segments:
               - title: API Key
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the API Key for this API Version.
+                  A 2-byte integer representing the API Key for this entry.
 
                   Here, it is 0x004b (75), which corresponds to the DescribeTopicPartitions API.
               - title: Min Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the minimum supported API Version for this API. 
+                  A 2-byte integer representing the minimum supported API Version for this entry. 
                   Here, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions 0 and up.
               - title: Max Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
-                  A 2-byte integer representing the maximum supported API Version for this API.
+                  A 2-byte integer representing the maximum supported API Version for this entry.
                   Here, it is 0x0000 (0), which means that the DescribeTopicPartitions API supports versions upto 0.
               - title: Tag Buffer
                 length_in_bytes: 1

--- a/binspec-visualizer/app/lib/format-registry.ts
+++ b/binspec-visualizer/app/lib/format-registry.ts
@@ -1,6 +1,8 @@
 import Format from './format';
 import generatedSQLiteDatabase from 'binspec-visualizer/data/formats/generated/sqlite-database';
 import kafkaApiVersionsRequestV4 from 'binspec-visualizer/data/formats/generated/kafka-api-versions-request-v4';
+import kafkaApiVersionsErrorResponse from 'binspec-visualizer/data/formats/generated/kafka-api-versions-response-unsupported-version';
+import kafkaApiVersionsResponseV4 from 'binspec-visualizer/data/formats/generated/kafka-api-versions-response-v4';
 import kafkaDescribeTopicPartitionsRequestV0 from 'binspec-visualizer/data/formats/generated/kafka-describe-topic-partitions-request-v0';
 import kafkaDescribeTopicPartitionsResponseV0 from 'binspec-visualizer/data/formats/generated/kafka-describe-topic-partitions-response-v0';
 import kafkaDescribeTopicPartitionsResponseV0UnknownTopic from 'binspec-visualizer/data/formats/generated/kafka-describe-topic-partitions-response-v0-unknown-topic';
@@ -23,6 +25,8 @@ export default class FormatRegistry {
       ),
       Format.fromGeneratedData(kafkaClusterMetadata),
       Format.fromGeneratedData(bittorentHandshake),
+      Format.fromGeneratedData(kafkaApiVersionsErrorResponse),
+      Format.fromGeneratedData(kafkaApiVersionsResponseV4),
     ];
   }
 }

--- a/binspec-visualizer/app/lib/format-registry.ts
+++ b/binspec-visualizer/app/lib/format-registry.ts
@@ -15,7 +15,7 @@ export default class FormatRegistry {
   }
 
   static get formats(): Format[] {
-    return [
+    const unsortedFormats = [
       Format.fromGeneratedData(generatedSQLiteDatabase),
       Format.fromGeneratedData(kafkaApiVersionsRequestV4),
       Format.fromGeneratedData(kafkaDescribeTopicPartitionsRequestV0),
@@ -28,5 +28,7 @@ export default class FormatRegistry {
       Format.fromGeneratedData(kafkaApiVersionsErrorResponse),
       Format.fromGeneratedData(kafkaApiVersionsResponseV4),
     ];
+
+    return unsortedFormats.sort((a, b) => a.name.localeCompare(b.name));
   }
 }


### PR DESCRIPTION
This pull request adds the APIVersions success and error response data files, as well as the generated TypeScript file for the unsupported version response. The APIVersions response data includes the message size, response header, API versions response body, and the array of API versions. The generated ts file contains the corresponding data in a TypeScript format.