### PR TITLE
Clarify unsigned varint

### DIFF
--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-v4.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-v4.ts
@@ -76,7 +76,7 @@ const generated: GeneratedData = {
             {
               "title": "Array Length",
               "length_in_bytes": 1,
-              "explanation_markdown": "The length of the API Versions array + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the array length is 3.\n"
+              "explanation_markdown": "The length of the API Versions array + 1, encoded as an unsigned varint. Here, it is 0x04 (4), meaning that the array length is 3.\n"
             },
             {
               "title": "API Version #1",

--- a/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-request-v0.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-request-v0.ts
@@ -105,7 +105,7 @@ const generated: GeneratedData = {
             {
               "title": "Array Length",
               "length_in_bytes": 1,
-              "explanation_markdown": "The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.\n"
+              "explanation_markdown": "The length of the topics array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning that the array length is 1.\n"
             },
             {
               "title": "Topic",
@@ -115,7 +115,7 @@ const generated: GeneratedData = {
                 {
                   "title": "Topic Name Length",
                   "length_in_bytes": 1,
-                  "explanation_markdown": "The length of the topic name + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the topic name is 3 bytes long.\n"
+                  "explanation_markdown": "The length of the topic name + 1, encoded as an unsigned varint. Here, it is 0x04 (4), meaning that the topic name is 3 bytes long.\n"
                 },
                 {
                   "title": "Topic Name",

--- a/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0-unknown-topic.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0-unknown-topic.ts
@@ -89,7 +89,7 @@ const generated: GeneratedData = {
             {
               "title": "Array Length",
               "length_in_bytes": 1,
-              "explanation_markdown": "The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.\n"
+              "explanation_markdown": "The length of the topics array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning that the array length is 1.\n"
             },
             {
               "title": "Topic #1",
@@ -108,7 +108,7 @@ const generated: GeneratedData = {
                     {
                       "title": "Length",
                       "length_in_bytes": 1,
-                      "explanation_markdown": "The length of the topic name + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the topic name is 3 bytes long.\n"
+                      "explanation_markdown": "The length of the topic name + 1, encoded as an unsigned varint. Here, it is 0x04 (4), meaning that the topic name is 3 bytes long.\n"
                     },
                     {
                       "title": "Contents",
@@ -130,7 +130,7 @@ const generated: GeneratedData = {
                 {
                   "title": "Partitions Array",
                   "length_in_bytes": 1,
-                  "explanation_markdown": "A `COMPACT_ARRAY` of partitions for this topic, which contains the length + 1 encoded as a varint, followed by the contents.\n\nHere, the length is 0x01 (1), indicating an empty array.\n"
+                  "explanation_markdown": "A `COMPACT_ARRAY` of partitions for this topic, which contains the length + 1 encoded as an unsigned varint, followed by the contents.\n\nHere, the length is 0x01 (1), indicating an empty array.\n"
                 },
                 {
                   "title": "Topic Authorized Operations",

--- a/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-describe-topic-partitions-response-v0.ts
@@ -145,7 +145,7 @@ const generated: GeneratedData = {
             {
               "title": "Array Length",
               "length_in_bytes": 1,
-              "explanation_markdown": "The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.\n"
+              "explanation_markdown": "The length of the topics array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning that the array length is 1.\n"
             },
             {
               "title": "Topic #1",
@@ -163,7 +163,7 @@ const generated: GeneratedData = {
                     {
                       "title": "String Length",
                       "length_in_bytes": 1,
-                      "explanation_markdown": "The length of the string + 1, encoded as a varint. Here, it is 0x04 (4), meaning the string length is 3.\n"
+                      "explanation_markdown": "The length of the string + 1, encoded as an unsigned varint. Here, it is 0x04 (4), meaning the string length is 3.\n"
                     },
                     {
                       "title": "String Content",
@@ -189,7 +189,7 @@ const generated: GeneratedData = {
                     {
                       "title": "Array Length",
                       "length_in_bytes": 1,
-                      "explanation_markdown": "The length of the partitions array + 1, encoded as a varint. Here, it is 0x03 (3), meaning the array length is 2.\n"
+                      "explanation_markdown": "The length of the partitions array + 1, encoded as an unsigned varint. Here, it is 0x03 (3), meaning the array length is 2.\n"
                     },
                     {
                       "title": "Partition 0",
@@ -222,7 +222,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the replica nodes array + 1, encoded as a varint. Here, it is 0x02 (2), meaning the array length is 1.\n"
+                              "explanation_markdown": "The length of the replica nodes array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning the array length is 1.\n"
                             },
                             {
                               "title": "Replica Node",
@@ -238,7 +238,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the ISR nodes array + 1, encoded as a varint. Here, it is 0x02 (2), meaning the array length is 1.\n"
+                              "explanation_markdown": "The length of the ISR nodes array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning the array length is 1.\n"
                             },
                             {
                               "title": "ISR Node",
@@ -254,7 +254,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                              "explanation_markdown": "The length of the Eligible Leader Replicas nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
                             }
                           ]
                         },
@@ -265,7 +265,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                              "explanation_markdown": "The length of the Last Known ELR nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
                             }
                           ]
                         },
@@ -276,7 +276,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                              "explanation_markdown": "The length of the Offline Replicas nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
                             }
                           ]
                         },
@@ -318,7 +318,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the replica nodes array + 1, encoded as a varint. Here, it is 0x02 (2), meaning the array length is 1.\n"
+                              "explanation_markdown": "The length of the replica nodes array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning the array length is 1.\n"
                             },
                             {
                               "title": "Replica Node",
@@ -334,7 +334,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the ISR nodes array + 1, encoded as a varint. Here, it is 0x02 (2), meaning the array length is 1.\n"
+                              "explanation_markdown": "The length of the ISR nodes array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning the array length is 1.\n"
                             },
                             {
                               "title": "ISR Node",
@@ -350,7 +350,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                              "explanation_markdown": "The length of the Eligible Leader Replicas nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
                             }
                           ]
                         },
@@ -361,7 +361,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                              "explanation_markdown": "The length of the Last Known ELR nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
                             }
                           ]
                         },
@@ -372,7 +372,7 @@ const generated: GeneratedData = {
                             {
                               "title": "Array Length",
                               "length_in_bytes": 1,
-                              "explanation_markdown": "The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
+                              "explanation_markdown": "The length of the Offline Replicas nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.\n"
                             }
                           ]
                         },

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
@@ -13,25 +13,25 @@ data:
   - 0x00
   - 0x04 # Number of APIVersions Keys (1 byte, 0x04 in hex, 4 in decimal)
   - 0x00 # API Key (2 bytes, 0x0001 in hex, 1 in decimal (Fetch API))
-  - 0x01 
+  - 0x01
   - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
   - 0x00
   - 0x00 # Max supported APIVersion (2 bytes, 0x0011 in hex, 17 in decimal)
-  - 0x11 
+  - 0x11
   - 0x00 # Empty tagged field array (1 byte, 0x00 in hex, 0 in decimal)
   - 0x00 # API Key (2 bytes, 0x0012 in hex, 18 in decimal (APIVersions API))
-  - 0x12 
+  - 0x12
   - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
   - 0x00
   - 0x00 # Max supported APIVersion (2 bytes, 0x0004 in hex, 4 in decimal)
-  - 0x04 
+  - 0x04
   - 0x00 # Empty tagged field array (1 byte, 0x00 in hex, 0 in decimal)
   - 0x00 # API Key (2 bytes, 0x004b in hex, 75 in decimal (DescribeTopicPartitions API))
-  - 0x4b 
+  - 0x4b
   - 0x00 # Min supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
   - 0x00
   - 0x00 # Max supported APIVersion (2 bytes, 0x0000 in hex, 0 in decimal)
-  - 0x00 
+  - 0x00
   - 0x00 # Empty tagged field array (1 byte, 0x00 in hex, 0 in decimal)
   - 0x00 # Throttle time (4 bytes, 0x00000000 in hex, 0 in decimal)
   - 0x00
@@ -81,7 +81,7 @@ segments:
           - title: Array Length
             length_in_bytes: 1
             explanation_markdown: |
-              The length of the API Versions array + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the array length is 3.
+              The length of the API Versions array + 1, encoded as an unsigned varint. Here, it is 0x04 (4), meaning that the array length is 3.
           - title: "API Version #1"
             explanation_markdown: |
               A single API Version in the array.

--- a/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-request-v0.yml
+++ b/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-request-v0.yml
@@ -101,7 +101,7 @@ segments:
           - title: Array Length
             length_in_bytes: 1
             explanation_markdown: |
-              The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.
+              The length of the topics array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning that the array length is 1.
           - title: Topic
             length_in_bytes: 5
             explanation_markdown: |
@@ -112,7 +112,7 @@ segments:
               - title: Topic Name Length
                 length_in_bytes: 1
                 explanation_markdown: |
-                  The length of the topic name + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the topic name is 3 bytes long.
+                  The length of the topic name + 1, encoded as an unsigned varint. Here, it is 0x04 (4), meaning that the topic name is 3 bytes long.
               - title: Topic Name
                 length_in_bytes: 3
                 explanation_markdown: |

--- a/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0-unknown-topic.yml
+++ b/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0-unknown-topic.yml
@@ -108,7 +108,7 @@ segments:
           - title: Array Length
             length_in_bytes: 1
             explanation_markdown: |
-              The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.
+              The length of the topics array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning that the array length is 1.
           - title: "Topic #1"
             explanation_markdown: |
               A single topic in the array.
@@ -127,7 +127,7 @@ segments:
                   - title: Length
                     length_in_bytes: 1
                     explanation_markdown: |
-                      The length of the topic name + 1, encoded as a varint. Here, it is 0x04 (4), meaning that the topic name is 3 bytes long.
+                      The length of the topic name + 1, encoded as an unsigned varint. Here, it is 0x04 (4), meaning that the topic name is 3 bytes long.
                   - title: Contents
                     length_in_bytes: 3
                     explanation_markdown: |
@@ -147,7 +147,7 @@ segments:
               - title: Partitions Array
                 length_in_bytes: 1
                 explanation_markdown: |
-                  A `COMPACT_ARRAY` of partitions for this topic, which contains the length + 1 encoded as a varint, followed by the contents.
+                  A `COMPACT_ARRAY` of partitions for this topic, which contains the length + 1 encoded as an unsigned varint, followed by the contents.
 
                   Here, the length is 0x01 (1), indicating an empty array.
               - title: Topic Authorized Operations

--- a/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0.yml
+++ b/binspec-visualizer/app/data/formats/kafka-describe-topic-partitions-response-v0.yml
@@ -164,7 +164,7 @@ segments:
           - title: Array Length
             length_in_bytes: 1
             explanation_markdown: |
-              The length of the topics array + 1, encoded as a varint. Here, it is 0x02 (2), meaning that the array length is 1.
+              The length of the topics array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning that the array length is 1.
           - title: "Topic #1"
             explanation_markdown: |
               A single topic in the array.
@@ -181,7 +181,7 @@ segments:
                   - title: String Length
                     length_in_bytes: 1
                     explanation_markdown: |
-                      The length of the string + 1, encoded as a varint. Here, it is 0x04 (4), meaning the string length is 3.
+                      The length of the string + 1, encoded as an unsigned varint. Here, it is 0x04 (4), meaning the string length is 3.
                   - title: String Content
                     length_in_bytes: 3
                     explanation_markdown: |
@@ -203,7 +203,7 @@ segments:
                   - title: Array Length
                     length_in_bytes: 1
                     explanation_markdown: |
-                      The length of the partitions array + 1, encoded as a varint. Here, it is 0x03 (3), meaning the array length is 2.
+                      The length of the partitions array + 1, encoded as an unsigned varint. Here, it is 0x03 (3), meaning the array length is 2.
                   - title: Partition 0
                     explanation_markdown: |
                       Information about the first partition.
@@ -235,7 +235,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the replica nodes array + 1, encoded as a varint. Here, it is 0x02 (2), meaning the array length is 1.
+                              The length of the replica nodes array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning the array length is 1.
                           - title: Replica Node
                             length_in_bytes: 4
                             explanation_markdown: |
@@ -248,7 +248,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the ISR nodes array + 1, encoded as a varint. Here, it is 0x02 (2), meaning the array length is 1.
+                              The length of the ISR nodes array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning the array length is 1.
                           - title: ISR Node
                             length_in_bytes: 4
                             explanation_markdown: |
@@ -261,7 +261,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                              The length of the Eligible Leader Replicas nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.
                       - title: Last Known ELR
                         explanation_markdown: |
                           An array of last known eligible leader replica node IDs (int32) for this partition.
@@ -269,7 +269,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                              The length of the Last Known ELR nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.
                       - title: Offline Replicas
                         explanation_markdown: |
                           An array of offline replica node IDs (int32) for this partition.
@@ -277,7 +277,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                              The length of the Offline Replicas nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.
                       - title: Tag Buffer
                         length_in_bytes: 1
                         explanation_markdown: |
@@ -313,7 +313,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the replica nodes array + 1, encoded as a varint. Here, it is 0x02 (2), meaning the array length is 1.
+                              The length of the replica nodes array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning the array length is 1.
                           - title: Replica Node
                             length_in_bytes: 4
                             explanation_markdown: |
@@ -326,7 +326,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the ISR nodes array + 1, encoded as a varint. Here, it is 0x02 (2), meaning the array length is 1.
+                              The length of the ISR nodes array + 1, encoded as an unsigned varint. Here, it is 0x02 (2), meaning the array length is 1.
                           - title: ISR Node
                             length_in_bytes: 4
                             explanation_markdown: |
@@ -339,7 +339,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the Eligible Leader Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                              The length of the Eligible Leader Replicas nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.
                       - title: Last Known ELR
                         explanation_markdown: |
                           An array of last known eligible leader replica node IDs (int32) for this partition.
@@ -347,7 +347,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the Last Known ELR nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                              The length of the Last Known ELR nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.
                       - title: Offline Replicas
                         explanation_markdown: |
                           An array of offline replica node IDs (int32) for this partition.
@@ -355,7 +355,7 @@ segments:
                           - title: Array Length
                             length_in_bytes: 1
                             explanation_markdown: |
-                              The length of the Offline Replicas nodes array + 1, encoded as a varint. Here, it is 0x01 (1), meaning the array length is 0.
+                              The length of the Offline Replicas nodes array + 1, encoded as an unsigned varint. Here, it is 0x01 (1), meaning the array length is 0.
                       - title: Tag Buffer
                         length_in_bytes: 1
                         explanation_markdown: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies that compact array/string length fields are encoded as unsigned varints across Kafka request/response specs and normalizes a few YAML byte listings.
> 
> - **Docs/Formats**:
>   - Replace references to `varint` with `unsigned varint` for `COMPACT_ARRAY` and `COMPACT_STRING` length fields in:
>     - `generated/kafka-api-versions-response-v4.ts`
>     - `generated/kafka-describe-topic-partitions-request-v0.ts`
>     - `generated/kafka-describe-topic-partitions-response-v0*.ts`
>     - `kafka-*-v0*.yml` counterparts
>   - Minor YAML cleanup: normalize hex byte entries in `kafka-api-versions-response-v4.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f72b46b4f77b9cf536338ad650ff692ecfc236fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->