### PR TITLE
Correct wrong numbers in kafka-cluster-metadata.yml

### DIFF
--- a/binspec-visualizer/app/data/formats/generated/kafka-cluster-metadata.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-cluster-metadata.ts
@@ -464,7 +464,7 @@ const generated: GeneratedData = {
                 {
                   "title": "Version",
                   "length_in_bytes": 1,
-                  "explanation_markdown": "Version is a 1-byte big-endian integer indicating the version of the feature level record.\n\nIn this case, the value is `0x01`, which is `1` in decimal.\n"
+                  "explanation_markdown": "Version is a 1-byte big-endian integer indicating the version of the feature level record.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\n"
                 },
                 {
                   "title": "Name length",
@@ -716,7 +716,7 @@ const generated: GeneratedData = {
                 {
                   "title": "Partition ID",
                   "length_in_bytes": 4,
-                  "explanation_markdown": "Partition ID is a 4-byte big-endian integer indicating the ID of the partition.\n\nIn this case, the value is `0x01`, which is `1` in decimal. Indicating that this Partition record is for partition `1`.\n"
+                  "explanation_markdown": "Partition ID is a 4-byte big-endian integer indicating the ID of the partition.\n\nIn this case, the value is `0x00`, which is `0` in decimal. Indicating that this Partition record is for partition `0`.\n"
                 },
                 {
                   "title": "Topic UUID",
@@ -854,7 +854,7 @@ const generated: GeneratedData = {
                 {
                   "title": "Partition ID",
                   "length_in_bytes": 4,
-                  "explanation_markdown": "Partition ID is a 4-byte big-endian integer indicating the ID of the partition.\n\nIn this case, the value is `0x00000000`, which is `0` in decimal. Indicating that this Partition record is for partition `0`.\n"
+                  "explanation_markdown": "Partition ID is a 4-byte big-endian integer indicating the ID of the partition.\n\nIn this case, the value is `0x01`, which is `1` in decimal. Indicating that this Partition record is for partition `1`.\n"
                 },
                 {
                   "title": "Topic UUID",

--- a/binspec-visualizer/app/data/formats/kafka-cluster-metadata.yml
+++ b/binspec-visualizer/app/data/formats/kafka-cluster-metadata.yml
@@ -533,7 +533,7 @@ segments:
                 explanation_markdown: |
                   Version is a 1-byte big-endian integer indicating the version of the feature level record.
 
-                  In this case, the value is `0x01`, which is `1` in decimal.
+                  In this case, the value is `0x00`, which is `0` in decimal.
               - title: Name length
                 length_in_bytes: 1
                 explanation_markdown: |
@@ -855,7 +855,7 @@ segments:
                 explanation_markdown: |
                   Partition ID is a 4-byte big-endian integer indicating the ID of the partition.
 
-                  In this case, the value is `0x01`, which is `1` in decimal. Indicating that this Partition record is for partition `1`.
+                  In this case, the value is `0x00`, which is `0` in decimal. Indicating that this Partition record is for partition `0`.
               - title: Topic UUID
                 length_in_bytes: 16
                 explanation_markdown: |
@@ -1023,7 +1023,7 @@ segments:
                 explanation_markdown: |
                   Partition ID is a 4-byte big-endian integer indicating the ID of the partition.
 
-                  In this case, the value is `0x00000000`, which is `0` in decimal. Indicating that this Partition record is for partition `0`.
+                  In this case, the value is `0x01`, which is `1` in decimal. Indicating that this Partition record is for partition `1`.
               - title: Topic UUID
                 length_in_bytes: 16
                 explanation_markdown: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes mis-stated values for Feature Level version and Partition ID explanations in kafka-cluster-metadata YAML and generated TS.
> 
> - **Formats (`kafka-cluster-metadata`)**:
>   - `app/data/formats/kafka-cluster-metadata.yml` and generated `app/data/formats/generated/kafka-cluster-metadata.ts`:
>     - Feature Level Record: correct `Version` explanation to `0x00` (0) instead of `0x01` (1).
>     - Partition Record: correct `Partition ID` explanations (swap 1↔0 in two records to match the data).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a0c7186a25e7e374e1b52fe7cd4efb088a973d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->