### PR TITLE
Clean up “ApiVersions”

### DIFF
--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-request-v4.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-request-v4.ts
@@ -2,7 +2,7 @@
 import type { GeneratedData } from "binspec-visualizer/lib/format";
 
 const generated: GeneratedData = {
-  "name": "Kafka API Versions Request (v4)",
+  "name": "Kafka ApiVersions Request (v4)",
   "slug": "kafka-api-versions-request-v4",
   "data": [
     0,
@@ -59,7 +59,7 @@ const generated: GeneratedData = {
         {
           "title": "API Key",
           "length_in_bytes": 2,
-          "explanation_markdown": "The API key is a 2-byte integer that identifies the API Key that this request is for.\n\nHere it is 0x12 (18), which corresponds to GetAPIVersions.\n"
+          "explanation_markdown": "The API key is a 2-byte integer that identifies the API Key that this request is for.\n\nHere it is 0x12 (18), which corresponds to ApiVersions.\n"
         },
         {
           "title": "API Version",

--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-unsupported-version.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-unsupported-version.ts
@@ -2,7 +2,7 @@
 import type { GeneratedData } from "binspec-visualizer/lib/format";
 
 const generated: GeneratedData = {
-  "name": "Kafka API Versions Error Response (v0)",
+  "name": "Kafka ApiVersions Error Response (v0)",
   "slug": "kafka-api-versions-response-unsupported-version",
   "data": [
     0,
@@ -44,8 +44,8 @@ const generated: GeneratedData = {
       ]
     },
     {
-      "title": "API Versions Response Body (v0)",
-      "explanation_markdown": "The response body contains fields specific to the API Versions response.\n",
+      "title": "ApiVersions Response Body (v0)",
+      "explanation_markdown": "The response body contains fields specific to the ApiVersions response.\n",
       "children": [
         {
           "title": "Error Code",
@@ -68,17 +68,17 @@ const generated: GeneratedData = {
                 {
                   "title": "API Key",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x0012 (18), which corresponds to the API Versions API.\n"
+                  "explanation_markdown": "A 2-byte integer representing the API Key for this API Version.\n\nHere, it is 0x0012 (18), which corresponds to the ApiVersions API.\n"
                 },
                 {
                   "title": "Min Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API.\nHere, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.\n"
+                  "explanation_markdown": "A 2-byte integer representing the minimum supported API Version for this API.\nHere, it is 0x0000 (0), which means that the ApiVersions API supports versions 0 and up.\n"
                 },
                 {
                   "title": "Max Supported API Version",
                   "length_in_bytes": 2,
-                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.\n"
+                  "explanation_markdown": "A 2-byte integer representing the maximum supported API Version for this API.\nHere, it is 0x0004 (4), which means that the ApiVersions API supports versions upto 4.\n"
                 }
               ]
             }

--- a/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-v4.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-api-versions-response-v4.ts
@@ -2,7 +2,7 @@
 import type { GeneratedData } from "binspec-visualizer/lib/format";
 
 const generated: GeneratedData = {
-  "name": "Kafka API Versions Response (v4)",
+  "name": "Kafka ApiVersions Response (v4)",
   "slug": "kafka-api-versions-Response-v4",
   "data": [
     0,
@@ -61,8 +61,8 @@ const generated: GeneratedData = {
       ]
     },
     {
-      "title": "API Versions Response Body (v4)",
-      "explanation_markdown": "The response body contains fields specific to the API Versions response.\n",
+      "title": "ApiVersions Response Body (v4)",
+      "explanation_markdown": "The response body contains fields specific to the ApiVersions response.\n",
       "children": [
         {
           "title": "Error Code",

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-request-v4.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-request-v4.yml
@@ -1,11 +1,11 @@
-name: Kafka API Versions Request (v4)
+name: Kafka ApiVersions Request (v4)
 slug: kafka-api-versions-request-v4
 data:
   - 0x00 # Message length (4 bytes, 0x23 in hex, 35 in decimal)
   - 0x00
   - 0x00
   - 0x23
-  - 0x00 # API key (2 bytes, 0x12 in hex, 18 in decimal => GetAPIVersions)
+  - 0x00 # API key (2 bytes, 0x12 in hex, 18 in decimal => ApiVersions)
   - 0x12
   - 0x00 # API version (2 bytes, 0x04 in hex, 4 in decimal)
   - 0x04
@@ -57,7 +57,7 @@ segments:
         explanation_markdown: |
           The API key is a 2-byte integer that identifies the API Key that this request is for.
 
-          Here it is 0x12 (18), which corresponds to GetAPIVersions.
+          Here it is 0x12 (18), which corresponds to ApiVersions.
       - title: API Version
         length_in_bytes: 2
         explanation_markdown: |

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-unsupported-version.yml
@@ -1,4 +1,4 @@
-name: Kafka API Versions Error Response (v0)
+name: Kafka ApiVersions Error Response (v0)
 slug: kafka-api-versions-response-unsupported-version
 data:
   - 0x00 # Message length (4 bytes, 0x10 in hex, 16 in decimal)
@@ -45,9 +45,9 @@ segments:
           The Correlation ID is a 4-byte integer that matches the ID sent in the corresponding request.
 
           Here, it is 0x07 (7).
-  - title: API Versions Response Body (v0)
+  - title: ApiVersions Response Body (v0)
     explanation_markdown: |
-      The response body contains fields specific to the API Versions response.
+      The response body contains fields specific to the ApiVersions response.
     children:
       - title: Error Code
         length_in_bytes: 2
@@ -77,14 +77,14 @@ segments:
                 explanation_markdown: |
                   A 2-byte integer representing the API Key for this API Version.
 
-                  Here, it is 0x0012 (18), which corresponds to the API Versions API.
+                  Here, it is 0x0012 (18), which corresponds to the ApiVersions API.
               - title: Min Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
                   A 2-byte integer representing the minimum supported API Version for this API.
-                  Here, it is 0x0000 (0), which means that the API Versions API supports versions 0 and up.
+                  Here, it is 0x0000 (0), which means that the ApiVersions API supports versions 0 and up.
               - title: Max Supported API Version
                 length_in_bytes: 2
                 explanation_markdown: |
                   A 2-byte integer representing the maximum supported API Version for this API.
-                  Here, it is 0x0004 (4), which means that the API Versions API supports versions upto 4.
+                  Here, it is 0x0004 (4), which means that the ApiVersions API supports versions upto 4.

--- a/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
+++ b/binspec-visualizer/app/data/formats/kafka-api-versions-response-v4.yml
@@ -1,4 +1,4 @@
-name: Kafka API Versions Response (v4)
+name: Kafka ApiVersions Response (v4)
 slug: kafka-api-versions-Response-v4
 data:
   - 0x00 # Message length (4 bytes, 0x21 in hex, 33 in decimal)
@@ -62,9 +62,9 @@ segments:
           The Correlation ID is a 4-byte integer that matches the ID sent in the corresponding request.
 
           Here, it is 0x07 (7).
-  - title: API Versions Response Body (v4)
+  - title: ApiVersions Response Body (v4)
     explanation_markdown: |
-      The response body contains fields specific to the API Versions response.
+      The response body contains fields specific to the ApiVersions response.
     children:
       - title: Error Code
         length_in_bytes: 2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames “API Versions” to “ApiVersions” across Kafka request/response format files and related explanations for consistency.
> 
> - **Data formats**:
>   - Rename labels/titles from `API Versions` to `ApiVersions` in `kafka-api-versions-request-v4` and responses (`kafka-api-versions-response-v4`, `kafka-api-versions-response-unsupported-version`).
>   - Update `explanation_markdown` references to the `ApiVersions` API and response body titles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0607a45d11b1a3d75bc92ee8f7f4e97f1a7f21f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->