### PR TITLE
Fix the type of the Headers Array Count

### DIFF
--- a/binspec-visualizer/app/data/formats/generated/kafka-cluster-metadata.ts
+++ b/binspec-visualizer/app/data/formats/generated/kafka-cluster-metadata.ts
@@ -491,7 +491,7 @@ const generated: GeneratedData = {
             {
               "title": "Headers Array Count",
               "length_in_bytes": 1,
-              "explanation_markdown": "Header array count is an unsigned variable size integer indicating the number of headers present.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\nSo, we can skip parsing the headers.\n"
+              "explanation_markdown": "Header array count is an signed variable size integer indicating the number of headers present.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\nSo, we can skip parsing the headers.\n"
             }
           ]
         }
@@ -650,7 +650,7 @@ const generated: GeneratedData = {
             {
               "title": "Headers Array Count",
               "length_in_bytes": 1,
-              "explanation_markdown": "Header array count is an unsigned variable size integer indicating the number of headers present.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\nSo, we can skip parsing the headers.\n"
+              "explanation_markdown": "Header array count is an signed variable size integer indicating the number of headers present.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\nSo, we can skip parsing the headers.\n"
             }
           ]
         },
@@ -788,7 +788,7 @@ const generated: GeneratedData = {
             {
               "title": "Headers Array Count",
               "length_in_bytes": 1,
-              "explanation_markdown": "Header array count is an unsigned variable size integer indicating the number of headers present.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\nSo, we can skip parsing the headers.\n"
+              "explanation_markdown": "Header array count is an signed variable size integer indicating the number of headers present.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\nSo, we can skip parsing the headers.\n"
             }
           ]
         },
@@ -926,7 +926,7 @@ const generated: GeneratedData = {
             {
               "title": "Headers Array Count",
               "length_in_bytes": 1,
-              "explanation_markdown": "Header array count is an unsigned variable size integer indicating the number of headers present.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\nSo, we can skip parsing the headers.\n"
+              "explanation_markdown": "Header array count is an signed variable size integer indicating the number of headers present.\n\nIn this case, the value is `0x00`, which is `0` in decimal.\nSo, we can skip parsing the headers.\n"
             }
           ]
         }

--- a/binspec-visualizer/app/data/formats/kafka-cluster-metadata.yml
+++ b/binspec-visualizer/app/data/formats/kafka-cluster-metadata.yml
@@ -563,7 +563,7 @@ segments:
           - title: Headers Array Count
             length_in_bytes: 1
             explanation_markdown: |
-              Header array count is an unsigned variable size integer indicating the number of headers present.
+              Header array count is an signed variable size integer indicating the number of headers present.
 
               In this case, the value is `0x00`, which is `0` in decimal.
               So, we can skip parsing the headers.
@@ -773,7 +773,7 @@ segments:
           - title: Headers Array Count
             length_in_bytes: 1
             explanation_markdown: |
-              Header array count is an unsigned variable size integer indicating the number of headers present.
+              Header array count is an signed variable size integer indicating the number of headers present.
 
               In this case, the value is `0x00`, which is `0` in decimal.
               So, we can skip parsing the headers.
@@ -949,7 +949,7 @@ segments:
           - title: Headers Array Count
             length_in_bytes: 1
             explanation_markdown: |
-              Header array count is an unsigned variable size integer indicating the number of headers present.
+              Header array count is an signed variable size integer indicating the number of headers present.
 
               In this case, the value is `0x00`, which is `0` in decimal.
               So, we can skip parsing the headers.
@@ -1125,7 +1125,7 @@ segments:
           - title: Headers Array Count
             length_in_bytes: 1
             explanation_markdown: |
-              Header array count is an unsigned variable size integer indicating the number of headers present.
+              Header array count is an signed variable size integer indicating the number of headers present.
 
               In this case, the value is `0x00`, which is `0` in decimal.
               So, we can skip parsing the headers.


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/issues-with-challenge-eg2/15760

Verification:

https://deepwiki.com/search/headerscount-in-record-is-sign_dc0e57a3-2817-4539-86ac-0b3680a0ccea?mode=fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only updates to the Kafka cluster metadata format spec and its generated output; no parsing or runtime logic changes.
> 
> **Overview**
> Corrects the Kafka cluster metadata format documentation so `Headers Array Count` is described as a *signed* variable-length integer rather than *unsigned*.
> 
> This change is applied in `kafka-cluster-metadata.yml` and the regenerated `generated/kafka-cluster-metadata.ts` so the visualizer shows the correct field type across all record examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d35d21a8708ae44f26e3f884d3844f173bdab37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->